### PR TITLE
protocolo dos arquivos pickle definido

### DIFF
--- a/src/gera_angle_sig.py
+++ b/src/gera_angle_sig.py
@@ -27,4 +27,4 @@ for im_file in fnames:
    h = h[0].astype(float)/float(h[0].sum())
    db[im_file] = np.hstack((cl[im_file],h))
    
-pickle.dump(db,open(sys.argv[4],"wb"))
+pickle.dump(db,open(sys.argv[5],"wb"),0)

--- a/src/gera_cd_sig.py
+++ b/src/gera_cd_sig.py
@@ -26,4 +26,4 @@ for im_file in fnames:
    h = h[0].astype(float)/float(h[0].sum())
    db[im_file] = np.hstack((cl[im_file],h))
    
-pickle.dump(db,open(sys.argv[4],"wb"))
+pickle.dump(db,open(sys.argv[6],"wb"),0)

--- a/src/gera_curvatura_sig.py
+++ b/src/gera_curvatura_sig.py
@@ -22,4 +22,4 @@ for im_file in fnames:
    db[im_file] = np.hstack((cl[im_file],h))
 #   print im_file,db[im_file]
    
-pickle.dump(db,open(sys.argv[6],"wb"))
+pickle.dump(db,open(sys.argv[6],"wb"),0)


### PR DESCRIPTION
Altera o protocolo dos arquivos pickle para o padrão do python 2 (0), no python 3 o padrão era 3 e criava conflito quando abria o arquivo rodando script em pyhton2.
Alterado também o parâmetro que pega o nome dos arquivos, pois estava pegando o valor errado do que era inserido pelo script em bash 

referencia: https://stackoverflow.com/questions/25843698/valueerror-unsupported-pickle-protocol-3-python2-pickle-can-not-load-the-file